### PR TITLE
[FIX] pos session couldn't be closed

### DIFF
--- a/l10n_fr_certification_abstract/__openerp__.py
+++ b/l10n_fr_certification_abstract/__openerp__.py
@@ -10,7 +10,7 @@
     "version": "8.0.1.0.0",
     "category": "Tools",
     "website": "https://odoo-community.org/",
-    "author": "GRAP, Akretion, Odoo Community Association (OCA), OpenERP SA",
+    "author": "GRAP, Akretion, Odoo Community Association (OCA), Aunéor Conseil, OpenERP SA",
     "license": "AGPL-3",
     "depends": [
         "base",

--- a/l10n_fr_certification_abstract/models/certification_model_mixin.py
+++ b/l10n_fr_certification_abstract/models/certification_model_mixin.py
@@ -81,7 +81,7 @@ class CertificationModelMixin(models.AbstractModel):
         locked_items = [x for x in self if x.l10n_fr_is_locked]
         if not locked_items:
             return
-        if 'state' in vals.keys():
+        if 'state' in vals.keys() and vals['state'] not in self._locked_state_list:
             raise UserError(_(
                 "According to the french law, you cannot modify the state"
                 " of the following items\n%s") % (


### PR DESCRIPTION
pos session couldn't be closed because of the state of the order that changed from paid to done (which should be an authorized change)